### PR TITLE
don't use private pydantic classes

### DIFF
--- a/py_directus/directus.py
+++ b/py_directus/directus.py
@@ -103,9 +103,7 @@ class Directus:
                 f"The provided collection model must be a subclass of pydantic.BaseModel"
             )
 
-            collection_name = collection.model_config.get("collection", None)
-
-            assert collection_name is not None
+            collection_name = collection.model_config["collection"]
 
             return DirectusRequest(self, collection_name, collection)
         elif isinstance(collection, str):

--- a/py_directus/models/base.py
+++ b/py_directus/models/base.py
@@ -1,34 +1,15 @@
-import re
-
-from pydantic import ConfigDict
-from pydantic._internal._config import ConfigWrapper
-from pydantic.main import _model_construction, BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class DirectusConfigDict(ConfigDict):
     collection: str
 
 
-class DirectusModelMetaclass(_model_construction.ModelMetaclass):
-    """
-    """
-
-    def __new__(cls, name, bases, namespace, *args, **kwargs):
-        """ Perform check for `collection` declaration """
-
-        tmp_config_wrapper = ConfigWrapper.for_model((), namespace, kwargs)
-        declared_collection = tmp_config_wrapper.config_dict.get("collection", None)
-
-        completed_class = super().__new__(cls, name, bases, namespace, *args, **kwargs)
-
-        class_config = getattr(completed_class, "model_config", None)
-
-        if not declared_collection:
-            output = re.findall("[A-Z]?[a-z]+", name)
-            class_config["collection"] = "_".join([word.lower() for word in output])
-
-        return completed_class
-
-
-class DirectusModel(BaseModel, metaclass=DirectusModelMetaclass):
-    pass
+class DirectusModel(BaseModel):
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__()
+        collection = cls.model_config.get('collection')
+        if not collection:
+            import re
+            collection = "_".join([word.lower() for word in re.findall("[A-Z]?[a-z]+", cls.__name__)])
+            cls.model_config["collection"] = collection


### PR DESCRIPTION
Current version doesn't work with pydantic 2.12 due to changes in the package-internal classes.